### PR TITLE
fix(SleepPreventer): block display sleep, screensaver, and screen lock

### DIFF
--- a/Lockpaw/Controllers/SleepPreventer.swift
+++ b/Lockpaw/Controllers/SleepPreventer.swift
@@ -1,3 +1,4 @@
+import Foundation
 import IOKit.pwr_mgt
 import os.log
 
@@ -5,25 +6,55 @@ private let logger = Logger(subsystem: "com.eriknielsen.lockpaw", category: "Sle
 
 class SleepPreventer {
     private var assertionID: IOPMAssertionID = IOPMAssertionID(0)
-    private var isActive = false
+    private var activityAssertionID: IOPMAssertionID = IOPMAssertionID(0)
+    private var activityTimer: Timer?
+    internal private(set) var isActive = false
 
     func preventSleep() {
         guard !isActive else { return }
-        let reason = "Lockpaw: Screen locked — preventing idle sleep" as CFString
+        let reason = "Lockpaw: Screen covered - preventing display sleep & screensaver" as CFString
         let result = IOPMAssertionCreateWithName(
-            kIOPMAssertionTypeNoIdleSleep as CFString,
+            kIOPMAssertionTypePreventUserIdleDisplaySleep as CFString,
             IOPMAssertionLevel(kIOPMAssertionLevelOn),
             reason, &assertionID
         )
-        if result == kIOReturnSuccess { isActive = true }
-        else { logger.error("Failed to create sleep assertion: \(result)") }
+        guard result == kIOReturnSuccess else {
+            logger.error("Failed to create display-sleep assertion: \(result)")
+            return
+        }
+        isActive = true
+        startActivityTimer()
     }
 
     func allowSleep() {
         guard isActive else { return }
+        stopActivityTimer()
         let result = IOPMAssertionRelease(assertionID)
-        if result != kIOReturnSuccess { logger.error("Failed to release sleep assertion: \(result)") }
+        if result != kIOReturnSuccess { logger.error("Failed to release assertion: \(result)") }
         isActive = false
+    }
+
+    private func startActivityTimer() {
+        stopActivityTimer()
+        declareUserActivity()
+        activityTimer = Timer.scheduledTimer(
+            withTimeInterval: Constants.Timing.userActivityRefreshInterval,
+            repeats: true
+        ) { [weak self] _ in self?.declareUserActivity() }
+    }
+
+    private func stopActivityTimer() {
+        activityTimer?.invalidate()
+        activityTimer = nil
+    }
+
+    private func declareUserActivity() {
+        let result = IOPMAssertionDeclareUserActivity(
+            "Lockpaw active" as CFString,
+            kIOPMUserActiveLocal,
+            &activityAssertionID
+        )
+        if result != kIOReturnSuccess { logger.error("DeclareUserActivity failed: \(result)") }
     }
 
     deinit { allowSleep() }

--- a/Lockpaw/Utilities/Constants.swift
+++ b/Lockpaw/Utilities/Constants.swift
@@ -15,6 +15,7 @@ enum Constants {
         static let authRateLimitCooldown: TimeInterval = 30.0         // seconds
         static let maxAuthAttempts = 3
         static let urlSchemeDebounce: TimeInterval = 0.1              // seconds
+        static let userActivityRefreshInterval: TimeInterval = 30     // seconds; defeats screensaver idle timer while locked
     }
 
     enum Anim {

--- a/LockpawTests/SleepPreventerTests.swift
+++ b/LockpawTests/SleepPreventerTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Lockpaw
+
+final class SleepPreventerTests: XCTestCase {
+    func testInitialState() {
+        XCTAssertFalse(SleepPreventer().isActive)
+    }
+
+    func testPreventSleepActivates() {
+        let p = SleepPreventer()
+        p.preventSleep()
+        XCTAssertTrue(p.isActive)
+        p.allowSleep()
+    }
+
+    func testAllowSleepDeactivates() {
+        let p = SleepPreventer()
+        p.preventSleep()
+        p.allowSleep()
+        XCTAssertFalse(p.isActive)
+    }
+
+    func testPreventSleepIsIdempotent() {
+        let p = SleepPreventer()
+        p.preventSleep()
+        p.preventSleep()
+        XCTAssertTrue(p.isActive)
+        p.allowSleep()
+    }
+
+    func testAllowSleepWithoutPreventIsSafe() {
+        let p = SleepPreventer()
+        p.allowSleep()
+        XCTAssertFalse(p.isActive)
+    }
+}


### PR DESCRIPTION
## Summary

`SleepPreventer` advertises (via the README) that it prevents display sleep, the screensaver, and the post-screensaver auto-lock. In practice it only blocks system idle sleep, because it uses `kIOPMAssertionTypeNoIdleSleep`. The display, screensaver, and `loginwindow` lock are governed by independent idle counters that this assertion type does not touch, so the paw image happily sits on screen while the display turns off and `loginwindow` locks behind it.

This PR makes the behavior match the claim: one-line root-cause fix on the assertion type, plus an `IOPMAssertionDeclareUserActivity` ping every 30s to defeat the screensaver's own idle counter. Equivalent to `caffeinate -du`.

Linked issue: sorkila/lockpaw#3

## Repro (before fix)

1. System Settings > Lock Screen
   - Turn display off when inactive: 1 minute
   - Start Screen Saver when inactive: 1 minute
   - Require password ... after screensaver / display off: Immediately
2. Trigger Lockpaw (`Cmd+Opt+Ctrl+L` by default).
3. Step away for ~90s.
4. Observed: display turns off behind the paw, `loginwindow` is what greets you on resume.

`pmset -g assertions` during the lock shows no Lockpaw assertion at all - `NoIdleSleep` is too narrow to register against display state.

## Fix

`Lockpaw/Controllers/SleepPreventer.swift`:

- Replace `kIOPMAssertionTypeNoIdleSleep` with `kIOPMAssertionTypePreventUserIdleDisplaySleep`. This is what actually keeps the display on, and the display staying on transitively prevents the screensaver from arming and the post-saver auto-lock from firing.
- Add a 30s `Timer` that calls `IOPMAssertionDeclareUserActivity(... kIOPMUserActiveLocal ...)` while locked. The screensaver runs off its own idle counter and `DeclareUserActivity` is the documented way to reset it. Without this ping, the screensaver can still arm even when the display assertion is active.
- Expose `isActive` as `internal private(set)` so the new unit tests can observe state transitions without changing the public API.

`Lockpaw/Utilities/Constants.swift`:

- Add `Constants.Timing.userActivityRefreshInterval` (30s) - no magic numbers in code per repo CLAUDE.md.

## Tests

`LockpawTests/SleepPreventerTests.swift` (new file, 5 tests):

- `testInitialState` - fresh instance is inactive
- `testPreventSleepActivates` - `preventSleep()` flips `isActive` to true
- `testAllowSleepDeactivates` - `allowSleep()` flips it back
- `testPreventSleepIsIdempotent` - double-call doesn't double-allocate
- `testAllowSleepWithoutPreventIsSafe` - guard prevents bogus release

Full suite green: 39 / 39 (34 existing + 5 new).

```
xcodebuild -project Lockpaw.xcodeproj -scheme Lockpaw -configuration Debug test
...
Test Suite 'All tests' passed at 2026-05-17 16:20:14.586.
    Executed 39 tests, with 0 failures (0 unexpected) in 0.027 (0.047) seconds
** TEST SUCCEEDED **
```

## Manual verification

With the dev build running and `Cmd+Opt+Ctrl+L` to lock:

- Before fix: `pmset -g assertions` shows no Lockpaw entry. With Lock Screen display-off set to 1m, the display goes dark within ~60s and `loginwindow` is in front on resume.
- After fix: `pmset -g assertions` shows `PreventUserIdleDisplaySleep` held by the Lockpaw process while locked, gone after `allowSleep()`. Display stays on indefinitely, no screensaver, Touch ID unlock returns straight to the Lockpaw unlock UI instead of `loginwindow`.

## Out of scope (intentional)

- README unchanged - the claim now matches behavior.
- `CHANGELOG.md` untouched - it stops at 1.0.2, maintainer handles versioning.
- No bundle-id change.
- No Sparkle / appcast change.
- No settings UI for the refresh interval - 30s is well under the lower bound of every relevant macOS idle timer.
