### PR TITLE
Add auth-required hotkey unlock setting

### DIFF
--- a/Lockpaw/Controllers/LockController.swift
+++ b/Lockpaw/Controllers/LockController.swift
@@ -43,7 +43,11 @@ class LockController: ObservableObject {
                 if self.state == .unlocked {
                     self.lock()
                 } else if self.state == .locked {
-                    self.quickUnlock()
+                    if HotkeyConfig.requiresAuthenticationToUnlock {
+                        self.requestUnlock()
+                    } else {
+                        self.quickUnlock()
+                    }
                 }
             }
         }

--- a/Lockpaw/Models/HotkeyConfig.swift
+++ b/Lockpaw/Models/HotkeyConfig.swift
@@ -6,11 +6,13 @@ struct HotkeyConfig {
     private static let modifiersKey = "hotkeyModifiers"
     private static let displayKey = "hotkeyDisplay"
     private static let enabledKey = "hotkeyEnabled"
+    static let requireAuthenticationToUnlockKey = "requireAuthenticationToUnlock"
 
     static let defaultKeyCode = 37
     static let defaultModifiers = cmdKey | shiftKey
     static let defaultDisplay = "Cmd+Shift+L"
     static let defaultEnabled = true
+    static let defaultRequireAuthenticationToUnlock = false
 
     static var keyCode: Int {
         UserDefaults.standard.object(forKey: keyCodeKey) as? Int ?? defaultKeyCode
@@ -28,6 +30,10 @@ struct HotkeyConfig {
         UserDefaults.standard.object(forKey: enabledKey) as? Bool ?? defaultEnabled
     }
 
+    static var requiresAuthenticationToUnlock: Bool {
+        UserDefaults.standard.object(forKey: requireAuthenticationToUnlockKey) as? Bool ?? defaultRequireAuthenticationToUnlock
+    }
+
     static func saveKeyCode(_ value: Int) {
         UserDefaults.standard.set(value, forKey: keyCodeKey)
     }
@@ -42,6 +48,10 @@ struct HotkeyConfig {
 
     static func saveEnabled(_ value: Bool) {
         UserDefaults.standard.set(value, forKey: enabledKey)
+    }
+
+    static func saveRequireAuthenticationToUnlock(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: requireAuthenticationToUnlockKey)
     }
 
     // MARK: - System Shortcut Conflict Detection

--- a/Lockpaw/Views/LockScreenView.swift
+++ b/Lockpaw/Views/LockScreenView.swift
@@ -12,6 +12,7 @@ struct LockScreenView: View {
 
     @AppStorage("showMessage") private var showMessage = true
     @AppStorage("lockMessage") private var message = Constants.defaultLockMessage
+    @AppStorage(HotkeyConfig.requireAuthenticationToUnlockKey) private var requiresAuthenticationToUnlock = HotkeyConfig.defaultRequireAuthenticationToUnlock
 
     @State private var phase: CGFloat = 0
     @State private var appeared = false
@@ -146,7 +147,7 @@ struct LockScreenView: View {
                             .transition(.opacity)
                         } else if showingHelp {
                             VStack(spacing: 16) {
-                                Text("Use your hotkey to unlock, or")
+                                Text(requiresAuthenticationToUnlock ? "Authentication required to unlock" : "Use your hotkey to unlock, or")
                                     .font(.system(size: 12, weight: .light))
                                     .foregroundStyle(.white.opacity(0.35))
                                     .tracking(0.3)
@@ -155,7 +156,7 @@ struct LockScreenView: View {
                                     NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .now)
                                     controller.requestUnlock()
                                 } label: {
-                                    Text("Authenticate with Touch ID")
+                                    Text(requiresAuthenticationToUnlock ? "Authenticate to Unlock" : "Authenticate with Touch ID")
                                         .font(.system(size: 13, weight: .medium))
                                         .foregroundStyle(.white.opacity(hoveringAuth ? 0.6 : 0.4))
                                         .tracking(0.3)

--- a/Lockpaw/Views/SettingsView.swift
+++ b/Lockpaw/Views/SettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AppKit
 import ServiceManagement
 import Sparkle
 import Carbon
@@ -54,6 +55,8 @@ final class UpdateCheckViewModel: NSObject, ObservableObject, SPUUpdaterDelegate
     }
 }
 
+private let buyMeACoffeeURL = URL(string: "https://www.buymeacoffee.com/eriknielsen")!
+
 struct SettingsView: View {
     @AppStorage("lockMessage") private var message = Constants.defaultLockMessage
     @AppStorage("showMessage") private var showMessage = true
@@ -62,6 +65,7 @@ struct SettingsView: View {
     @AppStorage("appearanceMode") private var appearanceMode = 0 // 0=System, 1=Light, 2=Dark
     @AppStorage("multiDisplayMode") private var multiDisplayMode = 0 // 0=Ambient, 1=Mirror
     @AppStorage("hotkeyDisplay") private var hotkeyDisplay = HotkeyConfig.defaultDisplay
+    @AppStorage(HotkeyConfig.requireAuthenticationToUnlockKey) private var requiresAuthenticationToUnlock = HotkeyConfig.defaultRequireAuthenticationToUnlock
 
     @ObservedObject var updateCheckViewModel: UpdateCheckViewModel
 
@@ -153,6 +157,8 @@ struct SettingsView: View {
                         .foregroundStyle(Color("LockpawError"))
                 }
 
+                Toggle("Require Touch ID or password to unlock", isOn: $requiresAuthenticationToUnlock)
+
                 Toggle("Global hotkey enabled", isOn: $hotkeyEnabled)
                     .onChange(of: hotkeyEnabled) { _, enabled in
                         NotificationCenter.default.post(
@@ -206,11 +212,17 @@ struct SettingsView: View {
                         Label("Version \(version) available", systemImage: "arrow.down.circle.fill")
                             .font(.callout)
                             .foregroundStyle(.blue)
-                    case .error(let message):
-                        Label(message, systemImage: "exclamationmark.triangle.fill")
+                    case .error(let msg):
+                        Label(msg, systemImage: "exclamationmark.triangle.fill")
                             .font(.callout)
                             .foregroundStyle(Color("LockpawError"))
                     }
+                }
+
+                Button {
+                    NSWorkspace.shared.open(buyMeACoffeeURL)
+                } label: {
+                    Label("Buy Me a Coffee", systemImage: "heart.fill")
                 }
             }
 

--- a/LockpawTests/HotkeyConfigTests.swift
+++ b/LockpawTests/HotkeyConfigTests.swift
@@ -3,6 +3,29 @@ import AppKit
 @testable import Lockpaw
 
 final class HotkeyConfigTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: HotkeyConfig.requireAuthenticationToUnlockKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: HotkeyConfig.requireAuthenticationToUnlockKey)
+        super.tearDown()
+    }
+
+    // MARK: - Unlock authentication preference
+
+    func testRequiresAuthenticationToUnlockDefaultsToFalse() {
+        XCTAssertFalse(HotkeyConfig.requiresAuthenticationToUnlock)
+    }
+
+    func testRequiresAuthenticationToUnlockPersists() {
+        HotkeyConfig.saveRequireAuthenticationToUnlock(true)
+        XCTAssertTrue(HotkeyConfig.requiresAuthenticationToUnlock)
+
+        HotkeyConfig.saveRequireAuthenticationToUnlock(false)
+        XCTAssertFalse(HotkeyConfig.requiresAuthenticationToUnlock)
+    }
 
     // MARK: - System conflict detection
 


### PR DESCRIPTION
## Summary

- Add a setting to require Touch ID or password when unlocking from the hotkey
- Keep quick hotkey unlock as the default behavior
- Update lock-screen helper copy when authentication is required
- Add the Buy Me a Coffee button to Settings

Closes #1

## Tests

- xcodebuild -project Lockpaw.xcodeproj -scheme Lockpaw -configuration Debug test