### PR TITLE
Prepare v1.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.0.8] - 2026-05-19
+
+### Added
+
+- Added a setting to require Touch ID or password when unlocking from the hotkey.
+- Added a Buy Me a Coffee button in Settings.
+
+### Fixed
+
+- Fixed display sleep, screensaver, and macOS lock activating behind Lockpaw while the screen is covered.
+
 ## [1.0.4] - 2026-03-30
 
 ### Fixed

--- a/Lockpaw/Info.plist
+++ b/Lockpaw/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.7</string>
+	<string>1.0.8</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>


### PR DESCRIPTION
## Summary

- Bump Lockpaw to 1.0.8 / build 9
- Add v1.0.8 changelog entry for the sleep prevention fix, auth-required unlock setting, and support button

## Tests

- xcodebuild -project Lockpaw.xcodeproj -scheme Lockpaw -configuration Debug test