### PR TITLE
Add Fade to black display protection while locked (closes #13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- Lock screen: **Fade to black** (Settings → Lock Screen, off by default) — after 1, 5, or 10 minutes of inactivity the lock screen fades to pure black to protect OLED displays. Agent pings breathe the teal glow for a few seconds, and any key or mouse movement brings the lock screen back (it returns to black after the same configured delay). The display never actually sleeps, so agents, automation, and the unlock hotkey keep working.
+
 ## [1.2.0] - 2026-08-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ tccutil reset Accessibility com.eriknielsen.lockpaw
 xcodebuild -project Lockpaw.xcodeproj -scheme Lockpaw -configuration Debug test
 ```
 
-50 unit tests covering LockState transitions, Constants formatting, HotkeyConfig conflict detection/auth-required unlock preference, SleepPreventer state handling, Mascot resolution, and PingDecision agent-ping branching.
+91 unit tests covering LockState transitions, Constants formatting, HotkeyConfig conflict detection/auth-required unlock preference, SleepPreventer state handling, Mascot resolution, PingDecision agent-ping branching, FadeToBlack preference resolution (checkbox × delay), and every branch of the PresentationLogic fade-to-black reducer.
 
 ## Release
 
@@ -68,13 +68,16 @@ Lockpaw/
 │   ├── HotkeyManager.swift         CGEventTap on dedicated background thread — global hotkey
 │   ├── OverlayWindowManager.swift  NSWindow per screen at CGShieldingWindowLevel
 │   ├── SleepPreventer.swift        IOKit sleep assertion
+│   ├── PresentationController.swift  Fade-to-black effects — timer slot, NSEvent monitors, cross-fades
 │   └── AgentNotifier.swift         UNUserNotificationCenter — "your agent needs you" (lazy auth)
 ├── Models/
 │   ├── LockState.swift             .unlocked → .locking → .locked → .unlocking
 │   ├── HotkeyConfig.swift          Centralized hotkey UserDefaults + system conflict detection/auth unlock preference
 │   ├── Mascot.swift                Dog/cat lock-screen mascot preference
+│   ├── FadeToBlack.swift           Fade-to-black preference + pure presentation reducer (LockPresentation / PresentationLogic)
 │   └── PingDecision.swift          Pure agent-ping decision (state + sound pref → pulse/notify/sound)
 ├── Views/
+│   ├── OverlayRootView.swift       Per-screen presentation switch — lock UI / pure black / attention pulse
 │   ├── LockScreenView.swift        Lock screen — mascot, timer, message, fallback auth, agent-ping glow
 │   ├── AmbientScreenView.swift     Secondary display — morphing gradient blobs
 │   ├── MenuBarView.swift           Menu bar dropdown
@@ -92,6 +95,8 @@ LockpawTests/                       (sibling of Lockpaw/)
 ├── ConstantsTests.swift            Time formatting (11 tests)
 ├── HotkeyConfigTests.swift         System shortcut conflict detection + auth unlock preference (9 tests)
 ├── SleepPreventerTests.swift       Sleep assertion state handling (5 tests)
+├── FadeToBlackTests.swift          Fade-to-black checkbox/delay resolution + timeout mapping (11 tests)
+├── PresentationLogicTests.swift    Presentation reducer: blackout/reveal/pulse/error branches (30 tests)
 ├── MascotTests.swift               Mascot resolution (3 tests)
 └── AgentPingTests.swift            PingDecision branching: locked/unlocked × sound (6 tests)
 
@@ -112,15 +117,26 @@ LockpawCLI/                         (sibling of Lockpaw/)
 - **Overlay dismiss does NOT call window.close()** — only `orderOut` + clear `contentView`. Calling `close()` during animated dismiss causes EXC_BAD_ACCESS in `_NSWindowTransformAnimation dealloc` (autorelease pool timing).
 
 ### Multi-display
-- **Primary vs ambient screens** — `OverlayWindowManager.showOverlay` takes a content factory `(Int, Bool) -> AnyView`. Primary screen shows full lock screen; secondary screens show `AmbientScreenView`.
+- **Primary vs ambient screens** — `OverlayWindowManager.showOverlay` takes a content factory `(Int, Bool) -> AnyView`. Every screen gets an `OverlayRootView`; while presentation is `.visible` the primary (or all screens in Mirror mode) shows the full lock screen and secondaries show `AmbientScreenView`.
 - **AmbientScreenView uses 5 morphing gradient blobs** — ellipses with solid fills at low opacity, heavy blur, on independent orbital paths. 3-second fade-in from black.
+
+### Fade to black (display protection)
+- **Why not real display sleep** — macOS's "require password after display off" locks the GUI session when the display sleeps, which revokes Accessibility from session apps: the hotkey taps die and agent automation breaks. Fade to black paints pure black over an *awake* display instead — OLED pixels off, session (and agents) fully alive. Off by default; a Settings → Lock Screen checkbox reveals a "Fade delay" row (1/5/10 min), mirroring the "Show lock message" → "Message" pattern.
+- **Presentation is a pure reducer, separate from LockState** — `PresentationLogic.reduce` (Models/FadeToBlack.swift) maps (presentation, armed timer, event, timeout) → decision; `PresentationController` only runs the effects. No presentation bug can touch the security-relevant lock state, and every branch is unit-tested.
+- **Single one-shot timer slot** — arming always invalidates the previous timer, so stale blackout/re-black fires are structurally impossible. A Combine sink on `$state` arms on every `.locked` entry (including re-entry after failed auth) and forces `.visible` + cancel on `.unlocking`; a sink on `$lastError` reveals errors and re-arms the configured fade delay as the re-black window (every reveal — input or error — reuses that one delay; there is no separate reveal constant) — cancelling instead would disarm protection for the rest of the session under auth rate limiting, which never leaves `.locked`.
+- **`.lockpawPhysicalInput` side channel** — InputBlocker's tap swallows keyboard/scroll before NSEvent monitors can see them, so the tap posts this (throttled) for physical events; mouse arrives via NSEvent global+local monitors in PresentationController.
+- **Physical vs synthetic: `eventSourceUnixProcessID == 0`** — hardware events carry PID 0; synthetic posts carry the poster's PID, so agent automation (cliclick, AppleScript) never lights the screen. Best-effort: remappers (Karabiner/BTT) repost under their own PID and won't reveal — the unlock hotkey ignores the filter, so recovery always works.
+- **The reveal click is consumed** — the local monitor returns nil for mouseDowns while not `.visible`, so the click that wakes the screen can never press the just-mounted auth button (the orphaned mouseUp is harmless).
+- **The attention pulse runs on every screen** — the primary lock UI is unmounted while black, so a ping breathes the lock screen's teal glow everywhere (`AttentionPulseView`, keyed by `attentionGeneration` so re-pings restart the breaths) for a bounded `Timing.attentionPulse`, then settles back to black. `agentAttention` survives blackness; on reveal the caption + resting glow appear (LockScreenView seeds `pingGlow` on appear). Under Reduce Motion the glow holds static at the pulse floor.
+- **The pointer stays with OverlayWindowManager's concealment in every presentation state** — fade-to-black adds no cursor calls of its own. An earlier revision hid via `NSCursor.hide()` while black, but mixing `hide()`/`unhide()` with `setHiddenUntilMouseMoves` is documented-unpredictable and in practice kills the idle re-hide for the rest of the session after the first reveal. Accepted trade: a synthetic mouse nudge can show the pointer over black for ~`Timing.cursorIdleHide` seconds before it re-conceals (the screen itself stays black — the PID filter ignores synthetic input).
+- **`stop()` leaves `presentation` untouched** — unlocking from black fades the overlay out from black with no lock-UI flash; the next `start()` resets it. `OverlayRootView`'s constant black backdrop is load-bearing: overlay windows have clear backgrounds, so the 6s cross-fade would otherwise blend through to the desktop.
 
 ### Agent alerts (the `lockpaw` CLI ping)
 - **Purpose** — when an AI agent (Claude Code, Codex, Gemini) pauses for permission or finishes while the screen is locked, the lock screen glows + a notification fires. Stays locked; you unlock when ready.
 - **Transport is DistributedNotificationCenter, NOT `lockpaw://`** — `open lockpaw://ping` would launch the app when it isn't running (wrong for a background ping). The CLI posts `com.eriknielsen.lockpaw.ping`; `AppDelegate` bridges it to a local `.lockpawPing`. The URL scheme stays for `lock`/`unlock` only.
 - **`PingDecision.make(state:soundEnabled:)` is pure** — locked → pulse + notify; any other state → no-op. Unit-tested directly (no UNUserNotificationCenter mocking). `LockController.handlePing()` debounces (`Timing.pingDebounce`) then applies the decision; `pingPulse` is a counter the lock screen watches via `.onChange`.
 - **Glow is the hero, not the banner** — on ping, `LockScreenView` breathes a saturated teal full-screen radial bloom (`pingPulseCount` breaths of `pingPulsePeriod`, mid-stop gradient + `.plusLighter`), then settles to a faint resting glow (`pingGlowRest`) with a standing "Your agent needs you" caption (`LockController.agentAttention`) until unlock. A generation counter cancels a stale pulse chain if a new ping lands mid-sequence. Notification is secondary; delivered banners are cleared on unlock (`AgentNotifier.clearDelivered()`). Sound is opt-in (`Constants.agentPingSoundKey`, default off, for shared offices).
-- **Cursor hides while locked** — `OverlayWindowManager` activates the app, makes the primary overlay key (`OverlayWindow` subclass: borderless windows refuse key status by default), then `NSCursor.setHiddenUntilMouseMoves(true)` — which is a no-op unless the app is active. Mouse-move monitors + an idle timer (`Timing.cursorIdleHide`) re-hide after stillness. Never `NSCursor.hide()` — an unbalanced hide would leave the pointer invisible over the auth button.
+- **Cursor hides while locked** — `OverlayWindowManager` activates the app, makes the primary overlay key (`OverlayWindow` subclass: borderless windows refuse key status by default), then `NSCursor.setHiddenUntilMouseMoves(true)` — which is a no-op unless the app is active. Mouse-move monitors + an idle timer (`Timing.cursorIdleHide`) re-hide after stillness. Never `NSCursor.hide()` — an unbalanced hide would leave the pointer invisible over the auth button, and even a balanced one breaks `setHiddenUntilMouseMoves` re-hides for the rest of the session (see the fade-to-black pointer note above).
 - **Lock-screen type uses four tokens** — `Font.lockBody/lockLabel/lockCaption/lockMono` in Constants.swift map to the DESIGN.md §2 scale; differentiate captions with opacity, never new sizes.
 - **The CLI lives in `Contents/SharedSupport/`, NOT `Contents/MacOS/`** — `lockpaw` would collide with the app binary `Lockpaw` on case-insensitive filesystems (DMG/Applications). `install-cli` symlinks it into `~/.local/bin`.
 - **The CLI target sets `PRODUCT_MODULE_NAME: LockpawCLI`** (executable stays `lockpaw`) — its Swift module would otherwise be `lockpaw`, which case-collides with the app's `Lockpaw` module and breaks `@testable import Lockpaw` on a clean build (`unable to resolve module dependency: 'Lockpaw'`). This only surfaces on a clean build (CI), not incremental local ones.
@@ -167,7 +183,7 @@ LockpawCLI/                         (sibling of Lockpaw/)
 
 ## CI / Distribution
 
-- **GitHub Actions CI** — build + 50 tests on `macos-15` runners (Xcode 16) on push to main and PRs (`.github/workflows/ci.yml`). Uses `actions/checkout@v7`.
+- **GitHub Actions CI** — build + 91 tests on `macos-15` runners (Xcode 16) on push to main and PRs (`.github/workflows/ci.yml`). Uses `actions/checkout@v7`.
 - **Release workflow** — tag `v*` → build → conditional sign/notarize (inside-out, not `--deep`) → branded DMG via `create-dmg` with Finder alias → GitHub Release (`.github/workflows/release.yml`). Handles pre-existing releases gracefully. **Note:** signing/notarization only runs if signing secrets are set — they are **not** currently configured, so a tag push creates a release but no signed DMG. Sign/notarize locally (or add the secrets).
 - **Latest release** — v1.2.0 released 2026-08-17 (build 13). DMG SHA-256: `0d8993fd3b1421aadcfd7299cf9cf33d7f7d8718affe076e83417cbed0d1cf51`. Six-agent hook support (Gemini real writer, Cursor, Copilot CLI, Aider). Full branded DMG; the build initially failed twice on `hdiutil detach` ("Resource busy" — Finder holds the volume after the styling AppleScript), fixed with a retry loop in `build-release.sh`.
 - **Sparkle auto-updates** — EdDSA-signed appcast at `https://getlockpaw.com/appcast.xml`, download URL points to GitHub Releases. Advertises **v1.2.0 / build 13**. ⚠️ The 1.1.1 appcast entry's enclosure is `https://getlockpaw.com/Lockpaw.dmg` and `lockpaw-web/Lockpaw.dmg` still holds the 1.1.1 bytes — do NOT overwrite that file with a newer DMG or the 1.1.1 entry's EdDSA signature stops matching for old clients.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,7 +106,9 @@ Motion is the moat. Two named, reusable signatures + a small curve set.
 | `ease-loop` | `0.45, 0, 0.55, 1` | `.easeInOut(…)` | Looping (glow out, breathing easing) |
 
 ### Durations
-`quick 0.2 · standard 0.35 · gentle 0.5 · entrance 0.8 · glow-in 0.45 · glow-out 1.6`
+`quick 0.2 · standard 0.35 · gentle 0.5 · entrance 0.8 · glow-in 0.45 · glow-out 1.6 · fade-to-black 6.0`
+
+`fade-to-black` is the one sanctioned duration above 1.6s — it empties the lock screen to pure black, so nothing competes with it.
 
 ### Choreography rules
 - **Enter fast, settle slow.** Reveals use `ease-out`; exits are quieter.

--- a/Lockpaw/Controllers/InputBlocker.swift
+++ b/Lockpaw/Controllers/InputBlocker.swift
@@ -15,6 +15,11 @@ class InputBlocker {
     var cachedKeyCode: Int64 = Int64(HotkeyConfig.defaultKeyCode)
     var cachedModifiers: Int = HotkeyConfig.defaultModifiers
 
+    /// Last time the tap posted `.lockpawPhysicalInput`. Only ever touched from the
+    /// tap callback, which runs on the run loop that installed it — the main run
+    /// loop, since startBlocking() is called from the main actor — so no locking.
+    var lastPhysicalInputPost = Date.distantPast
+
     private var hotkeyObserver: NSObjectProtocol?
 
     private static let eventMask: CGEventMask = {
@@ -64,6 +69,21 @@ class InputBlocker {
                         }
                     }
                     return nil
+                }
+
+                // Physical (hardware) events carry eventSourceUnixProcessID == 0;
+                // synthetic posts carry the poster's PID. Best-effort heuristic —
+                // signal fade-to-black that the user is present, throttled. The
+                // event is still swallowed below; blocking semantics are unchanged.
+                if event.getIntegerValueField(.eventSourceUnixProcessID) == 0, let refcon {
+                    let blocker = Unmanaged<InputBlocker>.fromOpaque(refcon).takeUnretainedValue()
+                    let now = Date()
+                    if now.timeIntervalSince(blocker.lastPhysicalInputPost) >= Constants.Timing.physicalInputThrottle {
+                        blocker.lastPhysicalInputPost = now
+                        DispatchQueue.main.async {
+                            NotificationCenter.default.post(name: .lockpawPhysicalInput, object: nil)
+                        }
+                    }
                 }
 
                 if type == .keyDown {

--- a/Lockpaw/Controllers/LockController.swift
+++ b/Lockpaw/Controllers/LockController.swift
@@ -27,6 +27,7 @@ class LockController: ObservableObject {
     private let inputBlocker = InputBlocker()
     private let authenticator = Authenticator()
     private let sleepPreventer = SleepPreventer()
+    private let presentationController = PresentationController()
 
     private var timer: Timer?
     private var sleepObserver: Any?
@@ -156,19 +157,15 @@ class LockController: ObservableObject {
         sleepPreventer.preventSleep()
 
         let mirrorAll = UserDefaults.standard.integer(forKey: "multiDisplayMode") == 1
+        let fadeTimeout = FadeToBlack.currentTimeout
         guard overlayManager.showOverlay(contentFactory: { [weak self] index, isPrimary in
             guard let self else { return AnyView(Color.black) }
-            if isPrimary || mirrorAll {
-                return AnyView(LockScreenView(
-                    controller: self,
-                    screenRole: .primary,
-                    phaseOffset: mirrorAll ? 0 : CGFloat(index) * 0.15
-                ))
-            } else {
-                return AnyView(AmbientScreenView(
-                    phaseOffset: CGFloat(index) * 0.15
-                ))
-            }
+            return AnyView(OverlayRootView(
+                controller: self,
+                presentationController: self.presentationController,
+                showsLockUI: isPrimary || mirrorAll,
+                phaseOffset: mirrorAll ? 0 : CGFloat(index) * 0.15
+            ))
         }) else {
             logger.error("Lock failed — no screens available for overlay")
             sleepPreventer.allowSleep()
@@ -177,6 +174,11 @@ class LockController: ObservableObject {
             scheduleErrorClear()
             return
         }
+
+        // After the overlay is up (the failure path above never starts anything) and
+        // before transitionTo(.locked) below, so the state sink observes the entry
+        // into .locked and arms the blackout timer.
+        presentationController.start(timeout: fadeTimeout, state: $state, error: $lastError)
 
         Task {
             try? await Task.sleep(nanoseconds: Constants.Timing.inputBlockerDelayNs)
@@ -319,6 +321,7 @@ class LockController: ObservableObject {
         if decision.shouldPulse {
             pingPulse &+= 1
             agentAttention = true
+            presentationController.notePing()
         }
         if decision.shouldNotify { AgentNotifier.shared.notify(withSound: decision.withSound) }
     }
@@ -354,6 +357,7 @@ class LockController: ObservableObject {
     }
 
     private func unlock() {
+        presentationController.stop()
         stopAccessibilityMonitoring()
         stopTimer()
         errorClearTask?.cancel()
@@ -367,6 +371,7 @@ class LockController: ObservableObject {
     }
 
     private func forceUnlock() {
+        presentationController.stop()
         authenticationInProgress = false
         isAuthenticating = false
         authenticator.cancelPending()

--- a/Lockpaw/Controllers/PresentationController.swift
+++ b/Lockpaw/Controllers/PresentationController.swift
@@ -1,0 +1,247 @@
+import AppKit
+import Combine
+import SwiftUI
+
+/// Drives what the lock overlay *shows* — the normal lock UI, pure black
+/// (fade-to-black burn-in protection), or a bounded agent-attention pulse —
+/// without ever touching the security-relevant `LockState`. All branching lives
+/// in `PresentationLogic` (pure, unit-tested); this class only runs the effects:
+/// one one-shot timer slot, NSEvent mouse monitors, the `.lockpawPhysicalInput`
+/// side channel, and per-direction cross-fade animations.
+@MainActor
+final class PresentationController: ObservableObject {
+    /// What every overlay screen renders. Mutated only via `setPresentation`.
+    @Published private(set) var presentation: LockPresentation = .visible
+
+    /// Bumped when a ping (re)starts the attention pulse — the pulse view keys off
+    /// it, and it guards stale pulse-end timer closures (same generation pattern as
+    /// LockScreenView.triggerPingGlow()).
+    @Published private(set) var attentionGeneration = 0
+
+    private var configuredTimeout: TimeInterval?
+    private var armed: ArmedTimer?
+    /// Single one-shot slot — arming always invalidates the previous timer, which
+    /// is what makes a stale blackout/reblack fire structurally impossible.
+    private var timer: Timer?
+    private var monitors: [Any] = []
+    private var physicalInputObserver: NSObjectProtocol?
+    private var cancellables = Set<AnyCancellable>()
+    private var active = false
+    private var lastHandledInput = Date.distantPast
+
+    private static let mouseMask: NSEvent.EventTypeMask = [
+        .mouseMoved, .leftMouseDown, .rightMouseDown, .otherMouseDown
+    ]
+
+    /// Called from lock() after the overlay is up and *before* the transition to
+    /// .locked — the state sink observes that entry and arms the blackout timer.
+    /// With `timeout == nil` (feature off) nothing is installed at all: no monitors,
+    /// no subscriptions, and `presentation` stays `.visible` for the whole session.
+    func start(
+        timeout: TimeInterval?,
+        state: Published<LockState>.Publisher,
+        error: Published<String?>.Publisher
+    ) {
+        stopInternals()
+        presentation = .visible  // pre-display reset; nothing is on screen yet
+        configuredTimeout = timeout
+        guard timeout != nil else { return }
+        active = true
+
+        // .locked entries arm (initial lock AND re-entry after a failed auth);
+        // anything else means the auth UI or teardown owns the screen.
+        state
+            .removeDuplicates()
+            .sink { [weak self] newState in
+                Task { @MainActor [weak self] in
+                    self?.apply(newState == .locked ? .lockEngaged : .lockStateLeftLocked)
+                }
+            }
+            .store(in: &cancellables)
+
+        // Errors must be visible wherever they're set (auth failure, rate limit,
+        // input-blocker failure, accessibility revocation, session interruption, …).
+        error
+            .compactMap { $0 }
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.apply(.errorSurfaced)
+                }
+            }
+            .store(in: &cancellables)
+
+        // Mouse comes in via NSEvent monitors (InputBlocker's tap doesn't touch mouse
+        // events). Keyboard/scroll never reach NSEvent — the tap swallows them and
+        // posts .lockpawPhysicalInput instead.
+        if let global = NSEvent.addGlobalMonitorForEvents(matching: Self.mouseMask, handler: { [weak self] event in
+            guard Self.isPhysical(event) else { return }
+            Task { @MainActor [weak self] in self?.notePhysicalInput() }
+        }) {
+            monitors.append(global)
+        }
+
+        // The local monitor must decide consumption synchronously, so no Task hop:
+        // handlers run on the main thread inside NSApp.sendEvent. Only a Bool crosses
+        // the assumeIsolated boundary (NSEvent isn't Sendable).
+        if let local = NSEvent.addLocalMonitorForEvents(matching: Self.mouseMask, handler: { [weak self] event in
+            guard let self else { return event }
+            let physical = Self.isPhysical(event)
+            let isMouseDown = event.type == .leftMouseDown
+                || event.type == .rightMouseDown
+                || event.type == .otherMouseDown
+            let consume = MainActor.assumeIsolated { () -> Bool in
+                if physical { self.notePhysicalInput() }
+                // Consume the reveal click so it can never press the auth button that
+                // is about to mount (the orphaned mouseUp is harmless — AppKit buttons
+                // need the down). Mouse moves always pass through so the cursor-rehide
+                // monitor in OverlayWindowManager keeps working.
+                return isMouseDown && self.presentation != .visible
+            }
+            return consume ? nil : event
+        }) {
+            monitors.append(local)
+        }
+
+        physicalInputObserver = NotificationCenter.default.addObserver(
+            forName: .lockpawPhysicalInput, object: nil, queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.notePhysicalInput() }
+        }
+    }
+
+    /// Called first thing in unlock()/forceUnlock(). Deliberately leaves
+    /// `presentation` untouched: unlocking from black should fade the overlay out
+    /// from black, not flash the lock UI — the next start() resets it.
+    func stop() {
+        stopInternals()
+    }
+
+    /// Called from handlePing() only when PingDecision said to pulse, so this
+    /// inherits the existing debounce and the state == .locked gate.
+    func notePing() {
+        guard active else { return }
+        apply(.agentPing)
+    }
+
+    deinit {
+        timer?.invalidate()
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        if let observer = physicalInputObserver { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    // MARK: - Private
+
+    private func stopInternals() {
+        cancellables.removeAll()
+        for monitor in monitors { NSEvent.removeMonitor(monitor) }
+        monitors.removeAll()
+        if let observer = physicalInputObserver {
+            NotificationCenter.default.removeObserver(observer)
+            physicalInputObserver = nil
+        }
+        timer?.invalidate()
+        timer = nil
+        armed = nil
+        active = false
+        configuredTimeout = nil
+    }
+
+    /// Hardware events carry eventSourceUnixProcessID == 0; synthetic posts carry the
+    /// poster's PID. Best-effort: input remappers (Karabiner, BTT) repost hardware
+    /// events under their own PID, so those users may need the unlock hotkey — which
+    /// ignores this filter entirely. Events with no CGEvent count as physical.
+    private static func isPhysical(_ event: NSEvent) -> Bool {
+        guard let cgEvent = event.cgEvent else { return true }
+        return cgEvent.getIntegerValueField(.eventSourceUnixProcessID) == 0
+    }
+
+    private func notePhysicalInput() {
+        guard active else { return }
+        if presentation == .visible {
+            // Mouse moves arrive at event rate — don't re-arm a Timer per pixel.
+            // The reveal path stays unthrottled so waking the screen is instant.
+            let now = Date()
+            guard now.timeIntervalSince(lastHandledInput) >= Constants.Timing.physicalInputThrottle else { return }
+            lastHandledInput = now
+        }
+        apply(.physicalInput)
+    }
+
+    /// The only place effects happen: reduce, then run the decision.
+    private func apply(_ event: PresentationEvent) {
+        let decision = PresentationLogic.reduce(
+            presentation: presentation, armed: armed, event: event, timeout: configuredTimeout
+        )
+        if decision.restartsAttentionPulse { attentionGeneration &+= 1 }
+        switch decision.timer {
+        case .none:
+            break
+        case .cancelAll:
+            timer?.invalidate()
+            timer = nil
+            armed = nil
+        case .armBlackout(let interval):
+            arm(.blackout, after: interval)
+        case .armReblack(let interval):
+            arm(.reblack, after: interval)
+        case .armAttentionEnd(let interval):
+            arm(.attentionEnd, after: interval)
+        }
+        setPresentation(decision.presentation)
+    }
+
+    private func arm(_ kind: ArmedTimer, after interval: TimeInterval) {
+        timer?.invalidate()
+        armed = kind
+        let generation = attentionGeneration
+        timer = Timer.scheduledTimer(withTimeInterval: interval, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.armed = nil
+                switch kind {
+                case .blackout, .reblack:
+                    self.apply(.inactivityTimerFired)
+                case .attentionEnd:
+                    // Belt-and-braces: the single slot already prevents stale fires,
+                    // but a re-ping bumps the generation and re-arms, so check anyway.
+                    guard generation == self.attentionGeneration else { return }
+                    self.apply(.attentionPulseEnded)
+                }
+            }
+        }
+    }
+
+    private func setPresentation(_ newPresentation: LockPresentation) {
+        guard newPresentation != presentation else { return }
+        if NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            presentation = newPresentation
+        } else {
+            withAnimation(Self.animation(from: presentation, to: newPresentation)) {
+                presentation = newPresentation
+            }
+        }
+        // Pointer concealment stays with OverlayWindowManager's
+        // setHiddenUntilMouseMoves machinery in every presentation state. Mixing
+        // NSCursor.hide()/unhide() into it breaks the idle re-hide for the rest of
+        // the session (documented as unpredictable when combined) — the cost is
+        // only that a synthetic mouse nudge can show the pointer over black for
+        // ~cursorIdleHide seconds before it re-conceals.
+    }
+
+    /// Direction-dependent cross-fade durations — the reason this uses withAnimation
+    /// at the mutation site rather than an .animation(_:value:) view modifier, which
+    /// can't express per-direction timing.
+    static func animation(from: LockPresentation, to: LockPresentation) -> Animation {
+        switch (from, to) {
+        case (.visible, .black):
+            return .easeInOut(duration: Constants.Timing.fadeToBlackDuration)
+        case (.attention, .black):
+            return .easeInOut(duration: Constants.Timing.attentionFadeOut)
+        case (_, .attention):
+            return .easeIn(duration: Constants.Timing.attentionFadeIn)
+        default:
+            return Constants.Anim.standard
+        }
+    }
+}

--- a/Lockpaw/Models/FadeToBlack.swift
+++ b/Lockpaw/Models/FadeToBlack.swift
@@ -1,0 +1,196 @@
+import Foundation
+
+/// User preference: fade the lock screen to pure black after inactivity.
+/// Burn-in protection without display sleep — real display sleep is off the table
+/// because "require password after display off" locks the GUI session and revokes
+/// Accessibility from session apps, killing the hotkey tap and agent automation.
+///
+/// Two UserDefaults keys, mirroring "Show lock message" + "Message": a checkbox
+/// (`enabledKey`, off by default) and the delay picker this enum models.
+enum FadeToBlack: String, CaseIterable, Identifiable {
+    case afterOneMinute
+    case afterFiveMinutes
+    case afterTenMinutes
+
+    /// Checkbox: fade to black at all? Off by default.
+    static let enabledKey = "fadeToBlackEnabled"
+    static let defaultEnabled = false
+
+    /// Delay picker, shown only while enabled.
+    static let storageKey = "fadeToBlack"
+    static let defaultValue = afterFiveMinutes.rawValue
+
+    var id: String { rawValue }
+
+    /// Idle time before the lock UI fades to black.
+    var timeout: TimeInterval {
+        switch self {
+        case .afterOneMinute: return 60
+        case .afterFiveMinutes: return 300
+        case .afterTenMinutes: return 600
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .afterOneMinute: return "1 min"
+        case .afterFiveMinutes: return "5 min"
+        case .afterTenMinutes: return "10 min"
+        }
+    }
+
+    static func resolved(from rawValue: String) -> FadeToBlack {
+        FadeToBlack(rawValue: rawValue) ?? .afterFiveMinutes
+    }
+
+    /// Stored delay preference (falls back to 5 min for unknown/legacy values —
+    /// the pre-checkbox build stored "off"/"afterFifteenMinutes" under this key).
+    static var current: FadeToBlack {
+        resolved(from: UserDefaults.standard.string(forKey: storageKey) ?? defaultValue)
+    }
+
+    /// The effective timeout: nil while the checkbox is off. Read once at lock()
+    /// time (like multiDisplayMode) — mid-lock changes apply on the next lock.
+    static var currentTimeout: TimeInterval? {
+        guard UserDefaults.standard.bool(forKey: enabledKey) else { return nil }
+        return current.timeout
+    }
+}
+
+/// What the lock overlay is showing. Purely presentational — never consulted by
+/// LockState, so no presentation bug can change the security-relevant lock state.
+enum LockPresentation: Equatable {
+    case visible    // normal lock UI (mascot on primary, ambient blobs on secondaries)
+    case black      // pure black, no view subtree mounted
+    case attention  // bounded ambient pulse while black (agent ping)
+}
+
+/// Everything that can influence presentation while locked.
+enum PresentationEvent: Equatable {
+    case lockEngaged           // entered .locked (initial lock and re-entry after failed auth)
+    case inactivityTimerFired  // blackout or re-black timer elapsed
+    case physicalInput         // hardware key/scroll (via InputBlocker) or mouse (via NSEvent monitors)
+    case agentPing             // debounced ping that PingDecision said should pulse
+    case attentionPulseEnded   // the bounded pulse ran its course
+    case errorSurfaced         // lastError set while locked — errors must be visible
+    case lockStateLeftLocked   // .unlocking / teardown — the auth UI owns the screen
+    case reset                 // stop()
+}
+
+/// Which one-shot timer PresentationController currently has armed (reducer input).
+enum ArmedTimer: Equatable {
+    case blackout      // counting down to fade-to-black
+    case reblack       // reveal window after physical input
+    case attentionEnd  // bounded attention pulse
+}
+
+/// What PresentationController must do with its single timer slot (reducer output).
+enum TimerDirective: Equatable {
+    case armBlackout(after: TimeInterval)
+    case armReblack(after: TimeInterval)
+    case armAttentionEnd(after: TimeInterval)
+    case cancelAll
+    case none  // leave whatever is running untouched
+}
+
+struct PresentationDecision: Equatable {
+    let presentation: LockPresentation
+    let timer: TimerDirective
+    let restartsAttentionPulse: Bool
+}
+
+/// Pure fade-to-black state machine, kept free of timers, UI, and side effects so
+/// every branch can be unit-tested directly (same philosophy as PingDecision).
+enum PresentationLogic {
+    static func reduce(
+        presentation: LockPresentation,
+        armed: ArmedTimer?,
+        event: PresentationEvent,
+        timeout: TimeInterval?
+    ) -> PresentationDecision {
+        switch event {
+        case .lockEngaged:
+            guard let timeout else {
+                return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+            }
+            return PresentationDecision(presentation: .visible, timer: .armBlackout(after: timeout), restartsAttentionPulse: false)
+
+        case .inactivityTimerFired:
+            guard presentation == .visible else {  // stale fire
+                return PresentationDecision(presentation: presentation, timer: .none, restartsAttentionPulse: false)
+            }
+            return PresentationDecision(presentation: .black, timer: .none, restartsAttentionPulse: false)
+
+        case .physicalInput:
+            switch presentation {
+            case .black, .attention:
+                guard let timeout else {
+                    return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+                }
+                return PresentationDecision(
+                    presentation: .visible,
+                    timer: .armReblack(after: timeout),
+                    restartsAttentionPulse: false
+                )
+            case .visible:
+                switch armed {
+                case .blackout:
+                    guard let timeout else {
+                        return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+                    }
+                    return PresentationDecision(presentation: .visible, timer: .armBlackout(after: timeout), restartsAttentionPulse: false)
+                case .reblack:
+                    guard let timeout else {
+                        return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+                    }
+                    return PresentationDecision(
+                        presentation: .visible,
+                        timer: .armReblack(after: timeout),
+                        restartsAttentionPulse: false
+                    )
+                case .attentionEnd, nil:
+                    // An empty (or foreign) slot arms nothing. This is what suspends
+                    // the idle clock during auth — the .unlocking transition cancelled
+                    // the slot — and what keeps "off" truly off.
+                    return PresentationDecision(presentation: .visible, timer: .none, restartsAttentionPulse: false)
+                }
+            }
+
+        case .agentPing:
+            guard presentation != .visible else {
+                // LockScreenView's own glow chain handles pings while visible.
+                return PresentationDecision(presentation: .visible, timer: .none, restartsAttentionPulse: false)
+            }
+            return PresentationDecision(
+                presentation: .attention,
+                timer: .armAttentionEnd(after: Constants.Timing.attentionPulse),
+                restartsAttentionPulse: true
+            )
+
+        case .attentionPulseEnded:
+            guard presentation == .attention else {  // stale fire
+                return PresentationDecision(presentation: presentation, timer: .none, restartsAttentionPulse: false)
+            }
+            return PresentationDecision(presentation: .black, timer: .none, restartsAttentionPulse: false)
+
+        case .errorSurfaced:
+            guard presentation != .visible else {
+                return PresentationDecision(presentation: .visible, timer: .none, restartsAttentionPulse: false)
+            }
+            // Reveal so the error is seen, but keep protection armed — cancelling here
+            // would disarm it for the rest of the session when the error path never
+            // leaves .locked (e.g. auth rate limiting).
+            guard let timeout else {
+                return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+            }
+            return PresentationDecision(
+                presentation: .visible,
+                timer: .armReblack(after: timeout),
+                restartsAttentionPulse: false
+            )
+
+        case .lockStateLeftLocked, .reset:
+            return PresentationDecision(presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false)
+        }
+    }
+}

--- a/Lockpaw/Utilities/Constants.swift
+++ b/Lockpaw/Utilities/Constants.swift
@@ -30,6 +30,15 @@ enum Constants {
         static let pingGlowRest: CGFloat = 0.08                       // faint glow held after the breaths until unlock — paired with the "agent needs you" hint
         static let cursorIdleHide: TimeInterval = 3.0                 // seconds of stillness before the pointer hides again while locked
         static let agentSetupMinSpin: TimeInterval = 1.2              // seconds; floor on the Settings connect-spinner so success registers
+
+        // Fade to black — dim the lock UI to pure black after inactivity (OLED burn-in guard).
+        static let fadeToBlackDuration: TimeInterval = 6.0            // visible → black fade; the one sanctioned >1.6s motion token (DESIGN.md §4)
+        static let attentionFadeIn: TimeInterval = 1.2                // black → attention pulse ease-in
+        static let attentionFadeOut: TimeInterval = 2.0               // attention → black settle
+        /// Time spent in .attention before settling back to black: entrance plus the
+        /// same breath budget as the lock-screen ping glow.
+        static let attentionPulse: TimeInterval = attentionFadeIn + Double(pingPulseCount) * pingPulsePeriod
+        static let physicalInputThrottle: TimeInterval = 0.5          // min spacing of physical-input signals (tap posts + timer re-arm churn)
     }
 
     enum Anim {

--- a/Lockpaw/Utilities/Notifications.swift
+++ b/Lockpaw/Utilities/Notifications.swift
@@ -11,4 +11,8 @@ extension Notification.Name {
     static let lockpawHotkeyPreferenceChanged = Notification.Name("lockpawHotkeyPreferenceChanged")
     /// Posted when an AI agent pings (bridged from the distributed notification, or fired by the in-app test button).
     static let lockpawPing = Notification.Name("lockpawPing")
+    /// Posted (throttled) by InputBlocker when a physical keyboard/scroll event hits its
+    /// tap while locked — the tap swallows those events before NSEvent monitors can see
+    /// them, so fade-to-black needs this side channel to reveal the lock UI.
+    static let lockpawPhysicalInput = Notification.Name("lockpawPhysicalInput")
 }

--- a/Lockpaw/Views/LockScreenView.swift
+++ b/Lockpaw/Views/LockScreenView.swift
@@ -218,6 +218,9 @@ struct LockScreenView: View {
         }
         .environment(\.colorScheme, .dark)
         .onAppear {
+            // Fade-to-black reveals remount this view with fresh @State — restore the
+            // resting glow after a ping (onChange(of: pingPulse) won't refire on mount).
+            if controller.agentAttention { pingGlow = Constants.Timing.pingGlowRest }
             withAnimation(reduceMotion ? .none : .timingCurve(0.16, 1, 0.3, 1, duration: 0.6)) { appeared = true }
             guard !reduceMotion else { return }
             withAnimation(Constants.Anim.breathe) { phase = Constants.Anim.breathePhaseTarget }

--- a/Lockpaw/Views/OverlayRootView.swift
+++ b/Lockpaw/Views/OverlayRootView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Per-screen root of the lock overlay: switches between the normal lock UI, pure
+/// black (fade-to-black burn-in protection), and the bounded agent-attention pulse.
+/// The constant black backdrop is load-bearing — overlay windows have clear
+/// backgrounds, so the slow cross-fade would otherwise blend through to the desktop.
+struct OverlayRootView: View {
+    @ObservedObject var controller: LockController
+    @ObservedObject var presentationController: PresentationController
+    /// Primary screen, or any screen in Mirror mode — shows the full lock UI.
+    let showsLockUI: Bool
+    let phaseOffset: CGFloat
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            switch presentationController.presentation {
+            case .visible:
+                if showsLockUI {
+                    LockScreenView(controller: controller, screenRole: .primary, phaseOffset: phaseOffset)
+                        .transition(.opacity)
+                } else {
+                    AmbientScreenView(phaseOffset: phaseOffset)
+                        .transition(.opacity)
+                }
+            case .black:
+                // Nothing mounted: no TimelineView, no breathing, no blob compositing.
+                EmptyView()
+            case .attention:
+                // Keyed by generation so a re-ping remounts and restarts the breaths.
+                AttentionPulseView()
+                    .id(presentationController.attentionGeneration)
+                    .transition(.opacity)
+            }
+        }
+        .ignoresSafeArea()
+    }
+}
+
+/// The agent-ping pulse while black, on every screen (the primary lock UI is
+/// unmounted): the lock screen's teal glow breathing the same envelope, rising from
+/// black and settling to the pulse floor until the attention window fades back out.
+/// Under Reduce Motion the glow holds at the floor with no motion.
+private struct AttentionPulseView: View {
+    @State private var glow: CGFloat = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        GeometryReader { geo in
+            RadialGradient(
+                stops: [
+                    .init(color: Color("LockpawTeal").opacity(0.30 * glow), location: 0),
+                    .init(color: Color("LockpawTeal").opacity(0.14 * glow), location: 0.45),
+                    .init(color: .clear, location: 1)
+                ],
+                center: .center,
+                startRadius: 0,
+                endRadius: max(geo.size.width, geo.size.height) * 0.8
+            )
+            .blendMode(.plusLighter)
+        }
+        .ignoresSafeArea()
+        .allowsHitTesting(false)
+        .onAppear {
+            guard !reduceMotion else {
+                glow = Constants.Timing.pingPulseFloor
+                return
+            }
+            let half = Constants.Timing.pingPulsePeriod / 2
+            for breath in 0..<Constants.Timing.pingPulseCount {
+                let start = Double(breath) * Constants.Timing.pingPulsePeriod
+                DispatchQueue.main.asyncAfter(deadline: .now() + start) {
+                    withAnimation(.easeInOut(duration: half)) { glow = 1 }
+                }
+                DispatchQueue.main.asyncAfter(deadline: .now() + start + half) {
+                    withAnimation(.easeInOut(duration: half)) { glow = Constants.Timing.pingPulseFloor }
+                }
+            }
+        }
+    }
+}

--- a/Lockpaw/Views/SettingsView.swift
+++ b/Lockpaw/Views/SettingsView.swift
@@ -110,6 +110,8 @@ struct SettingsView: View {
     @AppStorage("hotkeyDisplay") private var hotkeyDisplay = HotkeyConfig.defaultDisplay
     @AppStorage(HotkeyConfig.requireAuthenticationToUnlockKey) private var requiresAuthenticationToUnlock = HotkeyConfig.defaultRequireAuthenticationToUnlock
     @AppStorage(Constants.agentPingSoundKey) private var agentPingSound = false
+    @AppStorage(FadeToBlack.enabledKey) private var fadeToBlackEnabled = FadeToBlack.defaultEnabled
+    @AppStorage(FadeToBlack.storageKey) private var fadeToBlackDelay = FadeToBlack.defaultValue
 
     @ObservedObject var updateCheckViewModel: UpdateCheckViewModel
 
@@ -140,7 +142,7 @@ struct SettingsView: View {
         }
         .tint(settingsAccentColor)
         .accentColor(settingsAccentColor)
-        .frame(minWidth: 760, idealWidth: 820, minHeight: 720, idealHeight: 740)
+        .frame(minWidth: 760, idealWidth: 820, minHeight: 720, idealHeight: 820)
         .background(Color(nsColor: .windowBackgroundColor))
         .onAppear {
             NSApp.setActivationPolicy(.regular)
@@ -226,6 +228,24 @@ struct SettingsView: View {
                         options: [("Ambient", 0), ("Mirror", 1)],
                         width: 220
                     )
+                }
+
+                SettingsDivider()
+
+                SettingsRow("Fade to black", subtitle: "Fade to pure black while you're away. Agent pings still glow.") {
+                    SettingsCheckbox(isOn: $fadeToBlackEnabled)
+                }
+
+                if fadeToBlackEnabled {
+                    SettingsDivider()
+
+                    SettingsRow("Fade delay") {
+                        SettingsSegmentedControl(
+                            selection: $fadeToBlackDelay,
+                            options: FadeToBlack.allCases.map { ($0.displayName, $0.rawValue) },
+                            width: 210
+                        )
+                    }
                 }
 
                 SettingsDivider()
@@ -723,7 +743,9 @@ struct SettingsView: View {
         window.title = "Lockpaw Settings"
         window.minSize = NSSize(width: 760, height: 720)
 
-        let targetSize = NSSize(width: 820, height: 740)
+        // Tall enough for the tallest tab state (Lock Screen with Fade to black
+        // expanded, ≈807pt); small screens fall back to the page ScrollView.
+        let targetSize = NSSize(width: 820, height: 820)
         let contentSize = window.contentView?.frame.size ?? .zero
         if contentSize.width < targetSize.width || contentSize.height < targetSize.height {
             window.setContentSize(targetSize)

--- a/LockpawTests/FadeToBlackTests.swift
+++ b/LockpawTests/FadeToBlackTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Lockpaw
+
+final class FadeToBlackTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: FadeToBlack.enabledKey)
+        UserDefaults.standard.removeObject(forKey: FadeToBlack.storageKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: FadeToBlack.enabledKey)
+        UserDefaults.standard.removeObject(forKey: FadeToBlack.storageKey)
+        super.tearDown()
+    }
+
+    // MARK: - Defaults & resolution
+
+    func testDisabledByDefault() {
+        XCTAssertFalse(FadeToBlack.defaultEnabled)
+        XCTAssertNil(FadeToBlack.currentTimeout)  // unset defaults → feature off
+    }
+
+    func testDefaultDelayIsFiveMinutes() {
+        XCTAssertEqual(FadeToBlack.defaultValue, FadeToBlack.afterFiveMinutes.rawValue)
+    }
+
+    func testResolvedRoundTripsAllCases() {
+        for delay in FadeToBlack.allCases {
+            XCTAssertEqual(FadeToBlack.resolved(from: delay.rawValue), delay)
+        }
+    }
+
+    /// Unknown and legacy values (the pre-checkbox build stored "off" /
+    /// "afterFifteenMinutes" under the same key) fall back to the default delay.
+    func testResolvedFallsBackToDefaultDelay() {
+        XCTAssertEqual(FadeToBlack.resolved(from: "garbage"), .afterFiveMinutes)
+        XCTAssertEqual(FadeToBlack.resolved(from: "off"), .afterFiveMinutes)
+        XCTAssertEqual(FadeToBlack.resolved(from: "afterFifteenMinutes"), .afterFiveMinutes)
+    }
+
+    /// Pins the fallback and defaultValue together — they must never drift apart.
+    func testFallbackAgreesWithDefaultValue() {
+        XCTAssertEqual(FadeToBlack.resolved(from: "garbage").rawValue, FadeToBlack.defaultValue)
+    }
+
+    // MARK: - Presentation values
+
+    func testTimeoutMapping() {
+        XCTAssertEqual(FadeToBlack.afterOneMinute.timeout, 60)
+        XCTAssertEqual(FadeToBlack.afterFiveMinutes.timeout, 300)
+        XCTAssertEqual(FadeToBlack.afterTenMinutes.timeout, 600)
+    }
+
+    func testDisplayNames() {
+        XCTAssertEqual(FadeToBlack.afterOneMinute.displayName, "1 min")
+        XCTAssertEqual(FadeToBlack.afterFiveMinutes.displayName, "5 min")
+        XCTAssertEqual(FadeToBlack.afterTenMinutes.displayName, "10 min")
+    }
+
+    /// allCases drives the Settings segmented control — the order is user-facing.
+    func testAllCasesOrder() {
+        XCTAssertEqual(FadeToBlack.allCases, [.afterOneMinute, .afterFiveMinutes, .afterTenMinutes])
+    }
+
+    // MARK: - Effective timeout (checkbox × delay)
+
+    func testCurrentTimeoutNilWhileDisabledEvenWithDelayStored() {
+        UserDefaults.standard.set(FadeToBlack.afterOneMinute.rawValue, forKey: FadeToBlack.storageKey)
+        XCTAssertNil(FadeToBlack.currentTimeout)
+    }
+
+    func testCurrentTimeoutUsesStoredDelayWhenEnabled() {
+        UserDefaults.standard.set(true, forKey: FadeToBlack.enabledKey)
+        UserDefaults.standard.set(FadeToBlack.afterTenMinutes.rawValue, forKey: FadeToBlack.storageKey)
+        XCTAssertEqual(FadeToBlack.currentTimeout, 600)
+    }
+
+    func testCurrentTimeoutDefaultsToFiveMinutesWhenEnabledWithoutDelay() {
+        UserDefaults.standard.set(true, forKey: FadeToBlack.enabledKey)
+        XCTAssertEqual(FadeToBlack.currentTimeout, 300)
+    }
+}

--- a/LockpawTests/PresentationLogicTests.swift
+++ b/LockpawTests/PresentationLogicTests.swift
@@ -1,0 +1,289 @@
+import XCTest
+@testable import Lockpaw
+
+final class PresentationLogicTests: XCTestCase {
+    private let pulse = Constants.Timing.attentionPulse
+
+    private func reduce(
+        _ presentation: LockPresentation,
+        armed: ArmedTimer? = nil,
+        event: PresentationEvent,
+        timeout: TimeInterval? = 300
+    ) -> PresentationDecision {
+        PresentationLogic.reduce(presentation: presentation, armed: armed, event: event, timeout: timeout)
+    }
+
+    // MARK: - Lock engaged
+
+    func testLockEngagedArmsEachConfiguredTimeout() {
+        for timeout: TimeInterval in [60, 300, 900] {
+            let decision = reduce(.visible, event: .lockEngaged, timeout: timeout)
+            XCTAssertEqual(decision, PresentationDecision(
+                presentation: .visible, timer: .armBlackout(after: timeout), restartsAttentionPulse: false
+            ))
+        }
+    }
+
+    func testLockEngagedWithProtectionOffCancels() {
+        let decision = reduce(.visible, event: .lockEngaged, timeout: nil)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false
+        ))
+    }
+
+    func testLockEngagedForcesVisibleFromBlack() {
+        let decision = reduce(.black, armed: .reblack, event: .lockEngaged)
+        XCTAssertEqual(decision.presentation, .visible)
+        XCTAssertEqual(decision.timer, .armBlackout(after: 300))
+    }
+
+    // MARK: - Inactivity timer
+
+    func testInactivityFiredWhileVisibleGoesBlack() {
+        let decision = reduce(.visible, armed: .blackout, event: .inactivityTimerFired)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .black, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    func testInactivityFiredWhileBlackIsStale() {
+        let decision = reduce(.black, event: .inactivityTimerFired)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .black, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    func testInactivityFiredWhileAttentionIsStale() {
+        let decision = reduce(.attention, event: .inactivityTimerFired)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .attention, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    // MARK: - Physical input
+
+    func testPhysicalInputWhileBlackRevealsAndArmsReblack() {
+        let decision = reduce(.black, event: .physicalInput)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .armReblack(after: 300), restartsAttentionPulse: false
+        ))
+    }
+
+    func testPhysicalInputWhileAttentionRevealsAndArmsReblack() {
+        let decision = reduce(.attention, armed: .attentionEnd, event: .physicalInput)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .armReblack(after: 300), restartsAttentionPulse: false
+        ))
+    }
+
+    /// The reveal window is the configured fade delay — the same idle budget as
+    /// the initial fade, not a separate constant.
+    func testRevealWindowUsesConfiguredTimeout() {
+        for timeout: TimeInterval in [60, 300, 900] {
+            let decision = reduce(.black, event: .physicalInput, timeout: timeout)
+            XCTAssertEqual(decision.timer, .armReblack(after: timeout))
+        }
+    }
+
+    func testPhysicalInputWhileBlackWithNilTimeoutRevealsAndCancels() {
+        let decision = reduce(.black, event: .physicalInput, timeout: nil)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false
+        ))
+    }
+
+    func testPhysicalInputWhileVisibleWithBlackoutArmedRestartsIdleWindow() {
+        let decision = reduce(.visible, armed: .blackout, event: .physicalInput, timeout: 900)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .armBlackout(after: 900), restartsAttentionPulse: false
+        ))
+    }
+
+    func testPhysicalInputWhileVisibleWithReblackArmedExtendsRevealWindow() {
+        let decision = reduce(.visible, armed: .reblack, event: .physicalInput)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .armReblack(after: 300), restartsAttentionPulse: false
+        ))
+    }
+
+    func testPhysicalInputWithReblackArmedButNilTimeoutCancels() {
+        let decision = reduce(.visible, armed: .reblack, event: .physicalInput, timeout: nil)
+        XCTAssertEqual(decision.timer, .cancelAll)
+    }
+
+    /// The suspension rule: an empty slot arms nothing. This is what keeps the idle
+    /// clock stopped during auth (the .unlocking transition cancelled the slot).
+    func testPhysicalInputWhileVisibleWithEmptySlotArmsNothing() {
+        let decision = reduce(.visible, armed: nil, event: .physicalInput)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    func testPhysicalInputWithBlackoutArmedButNilTimeoutCancels() {
+        let decision = reduce(.visible, armed: .blackout, event: .physicalInput, timeout: nil)
+        XCTAssertEqual(decision.timer, .cancelAll)
+    }
+
+    // MARK: - Agent ping
+
+    func testAgentPingWhileBlackStartsAttentionPulse() {
+        let decision = reduce(.black, event: .agentPing)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .attention, timer: .armAttentionEnd(after: pulse), restartsAttentionPulse: true
+        ))
+    }
+
+    func testAgentPingWhileAttentionRestartsPulse() {
+        let first = reduce(.black, event: .agentPing)
+        let second = reduce(.attention, armed: .attentionEnd, event: .agentPing)
+        XCTAssertTrue(first.restartsAttentionPulse)
+        XCTAssertTrue(second.restartsAttentionPulse)
+        XCTAssertEqual(second.presentation, .attention)
+        XCTAssertEqual(second.timer, .armAttentionEnd(after: pulse))
+    }
+
+    func testAgentPingWhileVisibleIsNoOp() {
+        let decision = reduce(.visible, armed: .blackout, event: .agentPing)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    // MARK: - Attention pulse end
+
+    func testAttentionPulseEndedReturnsToBlack() {
+        let decision = reduce(.attention, event: .attentionPulseEnded)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .black, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    func testAttentionPulseEndedWhileVisibleIsStale() {
+        let decision = reduce(.visible, armed: .reblack, event: .attentionPulseEnded)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    func testAttentionPulseEndedWhileBlackIsStale() {
+        let decision = reduce(.black, event: .attentionPulseEnded)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .black, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    // MARK: - Errors
+
+    func testErrorSurfacedWhileBlackRevealsAndKeepsProtectionArmed() {
+        let decision = reduce(.black, event: .errorSurfaced)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .armReblack(after: 300), restartsAttentionPulse: false
+        ))
+    }
+
+    func testErrorSurfacedWhileAttentionReveals() {
+        let decision = reduce(.attention, armed: .attentionEnd, event: .errorSurfaced)
+        XCTAssertEqual(decision.presentation, .visible)
+        XCTAssertEqual(decision.timer, .armReblack(after: 300))
+    }
+
+    func testErrorSurfacedWhileBlackWithNilTimeoutRevealsAndCancels() {
+        let decision = reduce(.black, event: .errorSurfaced, timeout: nil)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false
+        ))
+    }
+
+    func testErrorSurfacedWhileVisibleIsNoOp() {
+        let decision = reduce(.visible, armed: .blackout, event: .errorSurfaced)
+        XCTAssertEqual(decision, PresentationDecision(
+            presentation: .visible, timer: .none, restartsAttentionPulse: false
+        ))
+    }
+
+    // MARK: - Leaving .locked / reset
+
+    func testLockStateLeftLockedForcesVisibleFromEveryPresentation() {
+        for presentation: LockPresentation in [.visible, .black, .attention] {
+            let decision = reduce(presentation, armed: .blackout, event: .lockStateLeftLocked)
+            XCTAssertEqual(decision, PresentationDecision(
+                presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false
+            ))
+        }
+    }
+
+    func testResetForcesVisibleFromEveryPresentation() {
+        for presentation: LockPresentation in [.visible, .black, .attention] {
+            let decision = reduce(presentation, armed: .attentionEnd, event: .reset)
+            XCTAssertEqual(decision, PresentationDecision(
+                presentation: .visible, timer: .cancelAll, restartsAttentionPulse: false
+            ))
+        }
+    }
+
+    // MARK: - Invariants & round trips
+
+    /// The pulse restarts on a ping landing while black/attention — and nowhere else.
+    func testRestartsAttentionPulseOnlyOnPingWhileNotVisible() {
+        let events: [PresentationEvent] = [
+            .lockEngaged, .inactivityTimerFired, .physicalInput, .agentPing,
+            .attentionPulseEnded, .errorSurfaced, .lockStateLeftLocked, .reset
+        ]
+        for presentation: LockPresentation in [.visible, .black, .attention] {
+            for event in events {
+                let decision = reduce(presentation, armed: .blackout, event: event)
+                let expected = (event == .agentPing && presentation != .visible)
+                XCTAssertEqual(decision.restartsAttentionPulse, expected,
+                               "\(presentation) + \(event) should\(expected ? "" : " not") restart the pulse")
+            }
+        }
+    }
+
+    /// Off never arms a timer, whatever happens.
+    func testProtectionOffNeverArmsFromAnyEvent() {
+        let events: [PresentationEvent] = [
+            .lockEngaged, .inactivityTimerFired, .physicalInput, .agentPing,
+            .attentionPulseEnded, .errorSurfaced, .lockStateLeftLocked, .reset
+        ]
+        for event in events {
+            let decision = reduce(.visible, armed: nil, event: event, timeout: nil)
+            switch decision.timer {
+            case .armBlackout, .armReblack:
+                XCTFail("Protection off must not arm an idle timer for \(event)")
+            case .armAttentionEnd, .cancelAll, .none:
+                break  // attention can still bound a pulse; cancel/none are fine
+            }
+        }
+    }
+
+    /// The canonical session: lock → idle → black → ping → attention → pulse end →
+    /// black → user returns → visible with a reveal window.
+    func testVisibleBlackAttentionBlackRevealRoundTrip() {
+        var presentation = LockPresentation.visible
+        var armed: ArmedTimer? = nil
+
+        func step(_ event: PresentationEvent) -> PresentationDecision {
+            let decision = reduce(presentation, armed: armed, event: event)
+            presentation = decision.presentation
+            switch decision.timer {
+            case .armBlackout: armed = .blackout
+            case .armReblack: armed = .reblack
+            case .armAttentionEnd: armed = .attentionEnd
+            case .cancelAll: armed = nil
+            case .none: break
+            }
+            return decision
+        }
+
+        XCTAssertEqual(step(.lockEngaged).timer, .armBlackout(after: 300))
+        armed = nil  // one-shot slot empties when it fires
+        XCTAssertEqual(step(.inactivityTimerFired).presentation, .black)
+        XCTAssertEqual(step(.agentPing).presentation, .attention)
+        armed = nil
+        XCTAssertEqual(step(.attentionPulseEnded).presentation, .black)
+        let reveal = step(.physicalInput)
+        XCTAssertEqual(reveal.presentation, .visible)
+        XCTAssertEqual(reveal.timer, .armReblack(after: 300))
+    }
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 - 🤖 **Agents keep running** — AI coding tools, builds, downloads, SSH sessions
 - 🔔 **Agent alerts** — the locked screen glows when Claude Code, Codex, Gemini, Cursor, Copilot, or Aider needs you
 - 😴 **Prevents sleep** — IOKit assertion keeps your Mac awake while locked
+- 🌑 **Fade to black** — optionally dim the lock screen to pure black after inactivity (OLED-safe) without ever sleeping the display, so agents keep running
 - 📦 **10 MB** — native Swift, no Electron
 - 🚫 **No analytics** — no data leaves your Mac, no accounts; the only network call is the signed update check
 - 🐕🐈 **Dog or cat mode** — choose the metallic origami dog or cat for the lock screen
@@ -237,7 +238,7 @@ LockpawCLI/
 
 ## CI
 
-Pushes to `main` and PRs run build + 50 unit tests via GitHub Actions. Shipped DMGs are Developer ID-signed, notarized, and published to [GitHub Releases](https://github.com/sorkila/lockpaw/releases); auto-updates are delivered through Sparkle with EdDSA-signed appcasts.
+Pushes to `main` and PRs run build + 91 unit tests via GitHub Actions. Shipped DMGs are Developer ID-signed, notarized, and published to [GitHub Releases](https://github.com/sorkila/lockpaw/releases); auto-updates are delivered through Sparkle with EdDSA-signed appcasts.
 
 <br>
 


### PR DESCRIPTION
First off — thank you for Lockpaw! It has become a daily part of my agent workflow, and the "screen glows when your agent needs you" idea is genuinely great. This PR is an attempt to give back.

It implements what @AJReade asked for in #13 — protecting displays from burn-in while locked — closes #13.

## What it does

An opt-in **Fade to black** mode (Settings → Lock Screen, off by default): while locked, the lock screen fades to pure black after 1, 5, or 10 minutes of inactivity, on every display. Any physical key or mouse movement brings the lock UI back, and it returns to black after the same configured delay. Agent pings still work while dark — the standard teal glow breathes on every screen, then settles back to black — and the pointer is concealed by the app's existing idle-hide (a synthetic mouse nudge can show it over black for a few seconds before it slips away again; the screen itself never lights for synthetic input). Under Reduce Motion, transitions are instant and the ping glow holds static.

## Why this shape (vs. real display sleep or a permanent blank mode)

- I first tried letting the displays actually sleep, but with macOS's "require password after display off" enabled, display sleep locks the GUI session and revokes Accessibility from session apps — the hotkey event taps die and agent automation breaks. Painting true black over an *awake* display turns OLED pixels off while the session (and everyone's agents) stay fully alive, which felt like the only shape compatible with what Lockpaw is for.
- I went with an idle fade rather than a permanent blank alternative so the mascot stays the hero while you're present, and protection kicks in exactly when you walk away. It's off by default to respect the app's restrained defaults — happy to change any of this if you'd prefer the literal blank-screen toggle from the issue.

## Implementation notes

- Presentation is a **pure reducer** (`PresentationLogic` in `Models/FadeToBlack.swift`), fully separate from `LockState` — no presentation bug can touch the security-relevant state machine, and every branch is unit-tested. `PresentationController` only runs the effects, with a single one-shot timer slot so stale timer fires are structurally impossible.
- InputBlocker's tap swallows keyboard/scroll before NSEvent monitors can see them, so it posts a throttled `.lockpawPhysicalInput` side channel; mouse arrives via NSEvent monitors. Synthetic input (cliclick, AppleScript, agent automation) is filtered by event-source PID so it never lights the screen — and the unlock hotkey ignores the filter, so recovery always works.
- The click that wakes the screen is consumed, so it can never press the just-mounted auth button.
- Settings follows the existing "Show lock message" → "Message" pattern: a checkbox reveals a "Fade delay" row. The window's ideal height grows to 820pt so the expanded tab fits without scrolling.
- Timing constants live in `Constants.Timing`, the notification in `Notifications.swift`, and the fade duration is documented in DESIGN.md §4, per the house conventions.

## Testing

- 41 new unit tests (suite 50 → 91): the `FadeToBlack` preference (checkbox × delay resolution, legacy-value fallback) and every branch of the presentation reducer (blackout, reveal, re-black, ping pulse, error, auth re-arm, reset).
- Verified on hardware: the 6s fade on all displays, ping-while-dark glow + re-ping restart, reveal/re-black windows, consumed reveal click, hotkey unlock from black (no lock-UI flash), auth-failure re-arm, error reveal, Mirror mode, Reduce Motion, and synthetic-vs-physical filtering.
- CHANGELOG, README, and CLAUDE.md are updated to match.

I tried to keep the diff as small as the feature allows (existing views are barely touched; `AmbientScreenView` is untouched). Very happy to adjust naming, defaults, timings, or scope — or split anything out — however you'd like. Thanks again for the app!

🤖 Generated with [Claude Code](https://claude.com/claude-code)


